### PR TITLE
Socat fix

### DIFF
--- a/socat/Dockerfile
+++ b/socat/Dockerfile
@@ -1,0 +1,11 @@
+FROM alpine:latest
+MAINTAINER devops@wpengine.com
+
+RUN apk add --update socat
+
+ENV LISTEN_PROTO=TCP4 \
+    LISTEN_PORT=11211 \
+    TARGET_SOCK=/socket
+
+CMD socat $LISTEN_PROTO-LISTEN:$LISTEN_PORT,bind=127.0.0.1,reuseaddr,fork,su=nobody,range=127.0.0.1/8 UNIX-CLIENT:$TARGET_SOCK
+

--- a/socat/Dockerfile
+++ b/socat/Dockerfile
@@ -7,5 +7,5 @@ ENV LISTEN_PROTO=TCP4 \
     LISTEN_PORT=11211 \
     TARGET_SOCK=/socket
 
-CMD socat $LISTEN_PROTO-LISTEN:$LISTEN_PORT,bind=127.0.0.1,reuseaddr,fork,su=nobody,range=127.0.0.1/8 UNIX-CLIENT:$TARGET_SOCK
+CMD socat $LISTEN_PROTO-LISTEN:$LISTEN_PORT,bind=127.0.0.1,reuseaddr,fork,su=nobody,range=127.0.0.1/8,unlink-close=0 UNIX-CLIENT:$TARGET_SOCK
 


### PR DESCRIPTION
Unlink-close should kill the process when the socket is unmounted, forcing the container to restart.