### PR TITLE
Add golang image

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.8
+
+# Install gometalinter
+RUN set -ex; \
+    go get -u -v github.com/alecthomas/gometalinter; \
+	gometalinter --install;
+
+# Install Glide
+ENV GLIDE_VERSION 0.12.3
+ENV GLIDE_SHA1 4d13f6a61e7325c8166629f00a4cb560d8a317c7
+RUN set -ex; \
+    curl -o glide.tar.gz -fSL "https://github.com/Masterminds/glide/releases/download/v$GLIDE_VERSION/glide-v$GLIDE_VERSION-linux-amd64.tar.gz"; \
+    echo "$GLIDE_SHA1 *glide.tar.gz" | sha1sum -c -; \
+    mkdir -p /tmp/glide; \
+    tar -xf glide.tar.gz -C /tmp/glide/; \
+    cp /tmp/glide/linux-amd64/glide /usr/bin/; \
+    rm -rf /tmp/glide glide.tar.gz
+

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,18 +1,9 @@
 FROM golang:1.8
 
-# Install gometalinter
 RUN set -ex; \
-    go get -u -v github.com/alecthomas/gometalinter; \
-	gometalinter --install;
-
-# Install Glide
-ENV GLIDE_VERSION 0.12.3
-ENV GLIDE_SHA1 4d13f6a61e7325c8166629f00a4cb560d8a317c7
-RUN set -ex; \
-    curl -o glide.tar.gz -fSL "https://github.com/Masterminds/glide/releases/download/v$GLIDE_VERSION/glide-v$GLIDE_VERSION-linux-amd64.tar.gz"; \
-    echo "$GLIDE_SHA1 *glide.tar.gz" | sha1sum -c -; \
-    mkdir -p /tmp/glide; \
-    tar -xf glide.tar.gz -C /tmp/glide/; \
-    cp /tmp/glide/linux-amd64/glide /usr/bin/; \
-    rm -rf /tmp/glide glide.tar.gz
-
+    go get -u -v \
+        github.com/alecthomas/gometalinter \
+        github.com/Masterminds/glide \
+    ; \
+    gometalinter --install; \
+    mv /go/bin/* /usr/local/go/bin/


### PR DESCRIPTION
This adds [gometalinter](https://github.com/alecthomas/gometalinter) and [glide](https://github.com/Masterminds/glide) to the offical golang image.  I'm going to set it up as a public automated docker build so that we don't have to add these dependencies to every pipeline and we can track upstream.

We're building from the [Debian buildpack](https://hub.docker.com/_/buildpack-deps/) golang image since that makes a better general build tool than the alpine images.