### PR TITLE
Add unit_tests script as entrypoint, add go package for better coverage and junit output

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -4,6 +4,11 @@ RUN set -ex; \
     go get -u -v \
         github.com/alecthomas/gometalinter \
         github.com/Masterminds/glide \
+        github.com/jstemmer/go-junit-report \
+        github.com/axw/gocov/gocov \
+        github.com/AlekSi/gocov-xml \
     ; \
     gometalinter --install; \
     mv /go/bin/* /usr/local/go/bin/
+
+COPY unit_tests.sh .

--- a/golang/unit_tests.sh
+++ b/golang/unit_tests.sh
@@ -1,0 +1,82 @@
+#!/bin/sh
+
+# Script to run all of our unit tests for each package,
+# output junit-xml reports, and output coverage reports.
+# Credits to: https://mlafeldt.github.io/blog/test-coverage-in-go/
+
+SCRIPT_NAME=$(basename $0)
+SCRIPT_DESC="Run unit and coverage tests for a go package"
+
+# Define variable for help text
+read -r -d '' HELP_TEXT <<HELP_BLOCK
+\n
+-h      Shows help screen and description
+-p      The path of the go package to test, relative to /go/src eg. github.com/wpengine/packagename
+\n
+HELP_BLOCK
+
+# Iterate through options
+while getopts ":hp:" opt; do
+    case $opt in
+        h)
+            echo "Name: $SCRIPT_NAME"
+            echo "Description: $SCRIPT_DESC"
+            echo -e "$HELP_TEXT"
+            exit 0
+            ;;
+        p)
+            export package_path="src/$OPTARG" >&2
+	          ;;
+        :)
+            echo "Option -$OPTARG requires an argument." >&2
+            exit 1
+            ;;
+    esac
+done
+
+if [[ -z $package_path ]]; then
+    echo -e "-p is required"
+    echo -e "$HELP_TEXT"
+    exit 1
+fi
+
+artifacts_test_dir="$package_path/artifacts/unit_tests"
+profile="$artifacts_test_dir/cover.out"
+mode="count"
+go_junit_report="/go/src/github.com/jstemmer/go-junit-report"
+
+mkdir -p artifacts_test_dir
+
+generate_cover_data() {
+  for package in $(go list ./$package_path/... | grep -v '/vendor/' \
+    | grep -v '/artifacts/')
+  do
+    f="$(echo $package | tr / -)"
+
+    # tee the test output so that we can see it in stdout
+    go test -v -covermode=$mode -coverprofile=$artifacts_test_dir/$f.cover $package 2>&1 | \
+    tee $artifacts_test_dir/temp-$f.out
+
+    # If there were tests, pipe that output into the junit-formatter for jenkins
+    if [ -f $artifacts_test_dir/temp-$f.out ]; then
+
+      cat $artifacts_test_dir/temp-$f.out | go run $go_junit_report/go-junit-report.go \
+      $go_junit_report/junit-formatter.go > $artifacts_test_dir/$f-report.xml
+    fi
+  done
+
+  echo "mode: $mode" > "$profile" # Necessary prefix for coverage report
+  grep -h -v "^mode:" "$artifacts_test_dir"/*.cover >> "$profile"
+
+  gocov convert $profile | gocov-xml > $artifacts_test_dir/coverage.xml
+}
+
+show_cover_report() {
+    go tool cover -html="$profile" -o $artifacts_test_dir/coverage.html
+}
+
+mkdir -p $artifacts_test_dir
+generate_cover_data
+show_cover_report
+
+chmod -r 777 $artifacts_test_dir


### PR DESCRIPTION
In support of CMWP-1336, we need to add better coverage and test tooling to our 'builder' image.