### PR TITLE
Rename outdated DTD URL

### DIFF
--- a/golang/unit_tests.sh
+++ b/golang/unit_tests.sh
@@ -77,7 +77,11 @@ generate_cover_data() {
   echo "mode: $mode" > "$profile" # Necessary prefix for coverage report
   grep -h -v "^mode:" "$artifacts_test_dir"/*.cover >> "$profile"
 
-  gocov convert $profile | gocov-xml > $artifacts_test_dir/coverage.xml
+  # gocov-xml uses an outdated url for the dtd. Update it.
+  gocov convert $profile | \
+    gocov-xml | \
+    sed 's%http://cobertura.sourceforge.net/xml/%https://raw.github.com/cobertura/cobertura/master/cobertura/src/site/htdocs/xml/%' > \
+    $artifacts_test_dir/coverage.xml
 }
 
 show_cover_report() {


### PR DESCRIPTION
Jenkins build is failing trying to parse the cobertura XML.  This is due to trying to use an outdated URL for the cobertura DTD.

This checkin replaces the old busted URL with a valid URL. This has been the valid URL, apparently, since 2013 https://github.com/cobertura/cobertura/issues/38

Here's what's output"
```
<!DOCTYPE coverage SYSTEM "https://raw.github.com/cobertura/cobertura/master/cobertura/src/site/htdocs/xml/coverage-03.dtd">
```

Before

```
$ groovy -classpath /Users/alan.arvesen/dev/lib/java/dom4j/dom4j-2.0.2.jar tmp.groovy 
Caught: org.dom4j.DocumentException: Connection reset
org.dom4j.DocumentException: Connection reset
	at org.dom4j.io.SAXReader.read(SAXReader.java:468)
	at org.dom4j.io.SAXReader.read(SAXReader.java:307)
	at org.dom4j.io.SAXReader$read.call(Unknown Source)
	at tmp.run(tmp.groovy:8)
```

After:
```
$ groovy -classpath /Users/alan.arvesen/dev/lib/java/dom4j/dom4j-2.0.2.jar tmp.groovy 
$
```