### PR TITLE
Bump Terraform Version

### DIFF
--- a/gcloud/terraform/Dockerfile
+++ b/gcloud/terraform/Dockerfile
@@ -1,6 +1,6 @@
 FROM google/cloud-sdk
 
-ENV TERRAFORM_VERSION=0.10.6
+ENV TERRAFORM_VERSION=0.10.7
 ENV TERRAFORM_URL=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y unzip


### PR DESCRIPTION
Would like to move to terraform v0.10.7 now that it is released. Specifically for the following bug fix:

> modules: Fix regression in the handling of modules sourcing other modules with relative paths (#16160)