### PR TITLE
Expanded Documentation

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2017 WP Engine
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # base-images-public
-This repo just contains base images we don't care about keeping private. Usually hosted on dockerhub with
-automated builds.
+
+This repository contains Dockerfiles and configuration scripts for Docker images containing various utilities. The resulting images are typically hosted on Docker Hub via automated builds.

--- a/gcloud/README.md
+++ b/gcloud/README.md
@@ -1,1 +1,3 @@
-# Some images that are just barely more than the base gcloud-sdk image
+# gcloud
+
+Collection of images that are based on the gcloud-sdk image.

--- a/gcloud/helm/README.md
+++ b/gcloud/helm/README.md
@@ -1,0 +1,15 @@
+# helm
+
+Image with the requirements to manage GKE / Kubernetes deploys with Helm.
+
+https://docs.helm.sh/
+
+## Usage
+
+Mount a service account private key and perform and upgrade:
+```
+docker run \
+    -v some/service_account.json:/service-account.json \
+    -e GOOGLE_APPLICATION_CREDENTIALS=/service-account.json
+    helm upgrade release_name
+```

--- a/gcloud/kubectl-make/README.md
+++ b/gcloud/kubectl-make/README.md
@@ -1,0 +1,3 @@
+# kubectl-make
+
+Docker image with gcloud, make, and jinja2 installed.

--- a/gcloud/terraform/README.md
+++ b/gcloud/terraform/README.md
@@ -1,0 +1,3 @@
+# terraform
+
+Docker image with gcloud, and terraform available.

--- a/golang/README.md
+++ b/golang/README.md
@@ -1,0 +1,28 @@
+# golang
+
+Golang base image with additional packages to assist in running unit tests.
+
+## Usage
+
+As a linter:
+```
+docker run --rm \
+    -v $(pwd):/go/src/${package_name} \
+    -w /go/src/${package_name} \
+    wpengine/golang gometalinter --vendor --disable-all --enable=golint --enable=vet --enable=gofmt ./...
+```
+
+Run unit tests:
+```
+docker run --rm -v \
+    $(pwd):/go/src/${package_name} \
+    wpengine/golang /bin/bash unit_tests.sh -p ${package_name}
+```
+
+Installing dependencies:
+```
+docker run --rm -v \
+    $(pwd):/go/src/${package_name} \
+    -w /go/src/${package_name} \
+    wpengine/golang glide install -v
+```

--- a/socat/README.md
+++ b/socat/README.md
@@ -1,0 +1,3 @@
+# socat
+
+Alpine image with socat installed.


### PR DESCRIPTION
The readme in the base of this repository ended up as the default for a handful of the images on Docker Hub. This PR:

* Massages the repo's readme
* Adds a readme for any subdirectory/image that did not already have one
* Includes the MIT license