### PR TITLE
Initial ansible lint and test image

### DIFF
--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -1,0 +1,37 @@
+FROM ubuntu:16.04
+
+# Install dependencies.
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+       python-software-properties \
+       python-dev \
+       python-setuptools \
+       python-pip \
+       build-essential \
+       software-properties-common \
+       rsyslog \
+       systemd \
+       systemd-cron \
+       sudo \
+    && rm -Rf /var/lib/apt/lists/* \
+    && rm -Rf /usr/share/doc && rm -Rf /usr/share/man \
+    && apt-get clean
+
+# Ensure latest pip version
+RUN pip install --upgrade pip
+
+ENV ANSIBLE_VERSION=2.2.3.0
+ENV ANSIBLE_LINT_VERSION=3.4.16
+ENV TESTINFRA_VERSION=1.8.0
+
+# Install Ansible
+RUN pip install ansible==${ANSIBLE_VERSION}
+
+# Testing and linting requirements
+RUN pip install ansible-lint==${ANSIBLE_LINT_VERSION}
+RUN pip install testinfra==${TESTINFRA_VERSION}
+
+# Disable / mock out some standard functionality that may be used in ansible roles under test
+RUN sed -i 's/^\($ModLoad imklog\)/#\1/' /etc/rsyslog.conf
+COPY initctl_faker .
+RUN chmod +x initctl_faker && rm -fr /sbin/initctl && ln -s /initctl_faker /sbin/initctl

--- a/ansible/README.md
+++ b/ansible/README.md
@@ -1,0 +1,18 @@
+# ansible
+
+[![Docker Automated build](https://img.shields.io/docker/automated/wpengine/ansible.svg?maxAge=2592000)](https://hub.docker.com/r/wpengine/ansible/)
+
+Ubuntu 16.04 LTS (Xenial) Docker container for Ansible playbook and role testing. Also includes the ansible-lint and testinfra python modules.
+
+## Usage
+
+Linting a playbook:
+```
+docker run --rm \
+    --volume=$(pwd)/ansible:/etc/ansible/:ro \
+    wpengine/ansible ansible-lint /etc/ansible/playbook.yml
+```
+
+## Credit
+
+Derived in part from Jeff Geerling's [geerlingguy/docker-ubuntu1604-ansible](https://github.com/geerlingguy/docker-ubuntu1604-ansible) image.

--- a/ansible/initctl_faker
+++ b/ansible/initctl_faker
@@ -1,0 +1,23 @@
+#!/bin/sh
+ALIAS_CMD="$(echo ""$0"" | sed -e 's?/sbin/??')"
+
+case "$ALIAS_CMD" in
+    start|stop|restart|reload|status)
+        exec service $1 $ALIAS_CMD
+        ;;
+esac
+
+case "$1" in
+    list )
+        exec service --status-all
+        ;;
+    reload-configuration )
+        exec service $2 restart
+        ;;
+    start|stop|restart|reload|status)
+        exec service $2 $1
+        ;;
+    \?)
+        exit 0
+        ;;
+esac


### PR DESCRIPTION
Adding a generic ansible image. My imagined use cases are:

* As a base image when validating packer templates using the docker builder + ansible provisioners
* Running testinfra tests inside the resulting packer-produced image
* ansible-lint in a container