### PR TITLE
Add Fluentd Image

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -1,0 +1,13 @@
+FROM fluent/fluentd:v1.0.0-onbuild
+
+RUN apk add --update --virtual .build-deps \
+        sudo build-base ruby-dev \
+ && sudo gem install \
+        fluent-plugin-record-modifier \
+        fluent-plugin-secure-forward \
+        fluent-plugin-formatter_sprintf \
+        fluent-plugin-bigquery \
+ && sudo gem sources --clear-all \
+ && apk del .build-deps \
+ && rm -rf /var/cache/apk/* \
+           /home/fluent/.gem/ruby/2.3.0/cache/*.gem

--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -1,0 +1,18 @@
+# fluentd
+
+A fluentd image based on fluent's official onbuild images. Includes additional fluentd plugins. In particular:
+
+* [fluent-plugin-record-modifier](https://github.com/repeatedly/fluent-plugin-record-modifier)
+* [fluent-plugin-secure-forward](https://github.com/tagomoris/fluent-plugin-secure-forward)
+* [fluent-plugin-formatter_sprintf](https://github.com/toyama0919/fluent-plugin-formatter_sprintf)
+* [fluent-plugin-bigquery](https://github.com/kaizenplatform/fluent-plugin-bigquery)
+
+## How to use this image
+
+Example run command:
+
+```
+docker run -d -p 24224:24224 -p 24224:24224/udp -v /data:/fluentd/log wpengine/fluentd
+```
+
+For additional documentation, refer to the base image readme at: https://github.com/fluent/fluentd-docker-image/blob/master/README.md#how-to-use-this-image

--- a/fluentd/README.md
+++ b/fluentd/README.md
@@ -7,6 +7,8 @@ A fluentd image based on fluent's official onbuild images. Includes additional f
 * [fluent-plugin-formatter_sprintf](https://github.com/toyama0919/fluent-plugin-formatter_sprintf)
 * [fluent-plugin-bigquery](https://github.com/kaizenplatform/fluent-plugin-bigquery)
 
+The base image Dockerfile can be viewed at: https://github.com/fluent/fluentd-docker-image/tree/master/v1.0/alpine-onbuild
+
 ## How to use this image
 
 Example run command:

--- a/fluentd/fluent.conf
+++ b/fluentd/fluent.conf
@@ -1,0 +1,33 @@
+<source>
+  @type  forward
+  @id    input1
+  @label @mainstream
+  port  24224
+</source>
+
+<filter **>
+  @type stdout
+</filter>
+
+<label @mainstream>
+  <match docker.**>
+    @type file
+    @id   output_docker1
+    path         /fluentd/log/docker.*.log
+    symlink_path /fluentd/log/docker.log
+    append       true
+    time_slice_format %Y%m%d
+    time_slice_wait   1m
+    time_format       %Y%m%dT%H%M%S%z
+  </match>
+  <match **>
+    @type file
+    @id   output1
+    path         /fluentd/log/data.*.log
+    symlink_path /fluentd/log/data.log
+    append       true
+    time_slice_format %Y%m%d
+    time_slice_wait   10m
+    time_format       %Y%m%dT%H%M%S%z
+  </match>
+</label>

--- a/fluentd/plugins/.gitignore
+++ b/fluentd/plugins/.gitignore
@@ -1,0 +1,2 @@
+# The fluent/fluentd onbuild source images expect to find a directory named "plugins" in the build context
+# This .gitignore file can be removed in the event we include fluentd plugins within this directory


### PR DESCRIPTION
Extending fluent's fluentd image per their documentation at: https://github.com/fluent/fluentd-docker-image/blob/master/README.md#how-to-build-your-own-image

The included fluent.conf is a copy/paste job from their repo. In most cases, we'd be providing our own config along with the `FLUENTD_CONF` env var at runtime.

