### PR TITLE
[EET-4592] Adding docker image with gcloud and docker

### DIFF
--- a/gcloud/docker/Dockerfile
+++ b/gcloud/docker/Dockerfile
@@ -1,11 +1,12 @@
 FROM google/cloud-sdk
 
-ENV DOCKER_VERSION 1.13.1-0~wheezy
+ENV DOCKER_VERSION 1.13.1-0~debian-jessie
 
 RUN apt-get update && \
     apt-get install -y apt-transport-https && \
     apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
-    echo 'deb http://http.debian.net/debian wheezy-backports main' > /etc/apt/sources.list.d/backports.list && \
-    echo 'deb https://apt.dockerproject.org/repo debian-wheezy main' > /etc/apt/sources.list.d/docker.list && \
+    echo 'deb http://http.debian.net/debian jessie-backports main' > /etc/apt/sources.list.d/backports.list && \
+    echo 'deb https://apt.dockerproject.org/repo debian-jessie main' > /etc/apt/sources.list.d/docker.list && \
     apt-get update && \
-    apt-get install -y docker-engine=$DOCKER_VERSION
+    apt-get install -y docker-engine=$DOCKER_VERSION && \
+    apt-get clean

--- a/gcloud/docker/Dockerfile
+++ b/gcloud/docker/Dockerfile
@@ -1,0 +1,11 @@
+FROM google/cloud-sdk
+
+ENV DOCKER_VERSION 1.13.1-0~wheezy
+
+RUN apt-get update && \
+    apt-get install -y apt-transport-https && \
+    apt-key adv --keyserver hkp://p80.pool.sks-keyservers.net:80 --recv-keys 58118E89F3A912897C070ADBF76221572C52609D && \
+    echo 'deb http://http.debian.net/debian wheezy-backports main' > /etc/apt/sources.list.d/backports.list && \
+    echo 'deb https://apt.dockerproject.org/repo debian-wheezy main' > /etc/apt/sources.list.d/docker.list && \
+    apt-get update && \
+    apt-get install -y docker-engine=$DOCKER_VERSION

--- a/gcloud/docker/README.md
+++ b/gcloud/docker/README.md
@@ -1,0 +1,3 @@
+# docker
+
+Docker image with gcloud and docker available


### PR DESCRIPTION
Creating our own docker image built on google/cloud-sdk with docker-engine installed.