### PR TITLE
Mirror shellcheck image

### DIFF
--- a/linters/shellcheck/Dockerfile
+++ b/linters/shellcheck/Dockerfile
@@ -1,0 +1,3 @@
+FROM koalaman/shellcheck:v0.4.7
+WORKDIR /shellcheck
+ENTRYPOINT ["/bin/shellcheck"]

--- a/linters/shellcheck/README.md
+++ b/linters/shellcheck/README.md
@@ -1,0 +1,13 @@
+# shellcheck
+
+A minimal shellcheck image useful for linting scripting files (e.g., bash scripts).
+
+https://github.com/koalaman/shellcheck/wiki
+
+usage
+=====
+
+Lint particular scripts
+```
+docker run --rm -v `pwd`:/shellcheck wpengine/shellcheck /shellcheck/script1.sh /shellcheck/script2.sh
+```


### PR DESCRIPTION
Adding a copy of the "official" [shellcheck docker image](https://github.com/koalaman/shellcheck/blob/master/Dockerfile) to our organization's repo so we can ensure the contents of the image.