### PR TITLE
NOJIRA: Remove redundant junit-formatter param

### DIFF
--- a/golang/unit_tests.sh
+++ b/golang/unit_tests.sh
@@ -70,7 +70,7 @@ generate_cover_data() {
     if [ -f $artifacts_test_dir/temp-$f.out ]; then
 
       cat $artifacts_test_dir/temp-$f.out | go run $go_junit_report/go-junit-report.go \
-      $go_junit_report/junit-formatter.go > $artifacts_test_dir/$f-report.xml
+      $go_junit_report/go-junit-formatter.go > $artifacts_test_dir/$f-report.xml
     fi
   done
 

--- a/golang/unit_tests.sh
+++ b/golang/unit_tests.sh
@@ -68,8 +68,7 @@ generate_cover_data() {
 
     # If there were tests, pipe that output into the junit-formatter for jenkins
     if [ -f $artifacts_test_dir/temp-$f.out ]; then
-      cat $artifacts_test_dir/temp-$f.out | go run $go_junit_report/go-junit-report.go \
-      $go_junit_report/formatter/formatter.go > $artifacts_test_dir/$f-report.xml
+      cat $artifacts_test_dir/temp-$f.out | go run $go_junit_report/go-junit-report.go > $artifacts_test_dir/$f-report.xml
     fi
   done
 

--- a/golang/unit_tests.sh
+++ b/golang/unit_tests.sh
@@ -68,9 +68,8 @@ generate_cover_data() {
 
     # If there were tests, pipe that output into the junit-formatter for jenkins
     if [ -f $artifacts_test_dir/temp-$f.out ]; then
-
       cat $artifacts_test_dir/temp-$f.out | go run $go_junit_report/go-junit-report.go \
-      $go_junit_report/go-junit-formatter.go > $artifacts_test_dir/$f-report.xml
+      $go_junit_report/formatter/formatter.go > $artifacts_test_dir/$f-report.xml
     fi
   done
 


### PR DESCRIPTION
The JUnit reports in our [Jenkins build](https://jenkins.wpengine.io/job/WPEngineGitHubRepos/job/ssh-gateway/job/master/306/consoleText) aren't generated because of the following error:
```
stat /go/src/github.com/jstemmer/go-junit-report/junit-formatter.go: no such file or directory
```

This PR attempts to resolve that, see this convo from `Jenkins Guild` on 3/19 for details:
```
[3:31 PM] Eric Haase: getting the following error in our build https://jenkins.wpengine.io/job/WPEngineGitHubRepos/job/ssh-gateway/job/master/306/ :
[3:31 PM] Eric Haase:
    stat /go/src/github.com/jstemmer/go-junit-report/junit-formatter.go: no such file or directory
[3:32 PM] Eric Haase: which should be included in our docker image according to https://hub.docker.com/r/wpengine/golang/~/dockerfile/
[3:32 PM] Eric Haase: the image was updated 2 days ago, any idea whats going on @ThomasBrezinski @sheriff ?
[3:41 PM] Thomas Brezinski:
    docker pull wpengine/golang
    Using default tag: latest
    latest: Pulling from wpengine/golang
    c73ab1c6897b: Pull complete
    1ab373b3deae: Pull complete
    b542772b4177: Pull complete
    57c8de432dbe: Pull complete
    c81227e1ec90: Pull complete
    c503a785f6fd: Pull complete
    0f90e5cd37cc: Pull complete
    8e848f75f6b2: Pull complete
    ce3e736b649b: Pull complete
    8108b95b8e92: Pull complete
    Digest: sha256:e1690bc3a7383fb3c9dd9518e0d419a0e7dadd3af8eb1dca5e2884747c36271f
    Status: Downloaded newer image for wpengine/golang:latest
     /local/wp/repo-mgmt ⮀ ⭠ master ● ⮀ docker run --rm -it wpengine/golang bash
    root@221871bf256d:/go# ls /go/src/github.com/jstemmer/go-junit-report/junit-formatter.go
    ls: cannot access '/go/src/github.com/jstemmer/go-junit-report/junit-formatter.go': No such file or directory
[3:42 PM] Thomas Brezinski:
    root@221871bf256d:/go# ls /go/src/github.com/jstemmer/go-junit-report/go-junit-report.go
    /go/src/github.com/jstemmer/go-junit-report/go-junit-report.go
[3:43 PM] Thomas Brezinski: I'd usually recommend pulling the image down on your laptop and poking around, looks like it's just a bad import missing the go- prefix
```