### PR TITLE
Fix cache dir mismatch

### DIFF
--- a/squid/Dockerfile
+++ b/squid/Dockerfile
@@ -1,5 +1,4 @@
 FROM ubuntu:16.04
-MAINTAINER thomas.brezinski@wpengine.com
 
 ENV SQUID_CACHE_DIR=/var/spool/squid \
     SQUID_LOG_DIR=/var/log/squid \

--- a/squid/squid.conf
+++ b/squid/squid.conf
@@ -24,8 +24,8 @@ http_access allow localnet
 http_access allow localhost
 http_access deny all
 http_port 3128
-cache_dir ufs /var/spool/squid3 100 16 256
-coredump_dir /var/spool/squid3
+cache_dir ufs /var/spool/squid 100 16 256
+coredump_dir /var/spool/squid
 refresh_pattern ^ftp:		1440	20%	10080
 refresh_pattern ^gopher:	1440	0%	1440
 refresh_pattern -i (/cgi-bin/|\?) 0	0%	0


### PR DESCRIPTION
The cache dir was mismatched between the env vars set in the Dockerfile and squid.conf causing squid to crash on start.