### PR TITLE
Add minimal flake8 image

### DIFF
--- a/linters/flake8/.flake8
+++ b/linters/flake8/.flake8
@@ -1,0 +1,9 @@
+[flake8]
+max-line-length = 120
+max-complexity = 10
+exclude =
+    config/settings/*.py,
+    apps/*/migrations/*.py,
+    manage.py
+
+statistics = True

--- a/linters/flake8/Dockerfile
+++ b/linters/flake8/Dockerfile
@@ -1,7 +1,8 @@
 FROM python:3.6
 ENV PYTHON_UNBUFFERED 1
+
 RUN pip install flake8
 
-WORKDIR /flake8
+COPY .flake8 /
 
-ENTRYPOINT [ "flake8" ]
+ENTRYPOINT ["flake8", "--config=/.flake8"]

--- a/linters/flake8/Dockerfile
+++ b/linters/flake8/Dockerfile
@@ -1,0 +1,7 @@
+FROM python:3.6
+ENV PYTHON_UNBUFFERED 1
+RUN pip install flake8
+
+WORKDIR /flake8
+
+ENTRYPOINT [ "flake8" ]

--- a/linters/flake8/README.md
+++ b/linters/flake8/README.md
@@ -16,4 +16,9 @@ docker run --rm -v `pwd`:/workspace wpengine/flake8 /workspace
 configuration
 =============
 
-The .flake8 configuration file in the target lint directory should override flake8's default settings.
+There is an included flake8 file that enforces some sane defaults for django projects. If you would like to
+override the configuration, you must mount your flake8 file over the system one.
+
+```
+docker run --rm -v `pwd`:/workspace -v /full/path/to/.flake8:/.flake8 wpengine/flake8 /workspace
+```

--- a/linters/flake8/README.md
+++ b/linters/flake8/README.md
@@ -1,0 +1,19 @@
+# flake8
+
+A minimal flake8 image useful for linting python files.
+
+https://flake8.pycqa.org/
+
+usage
+=====
+
+// Lint all python files in the current and sub directories
+
+```
+docker run --rm -v `pwd`:/workspace wpengine/flake8 /workspace
+```
+
+configuration
+=============
+
+The .flake8 configuration file in the target lint directory should override flake8's default settings.


### PR DESCRIPTION
This PR adds a minimal flake8 image. We are moving away from pylint back to flake8 and there are some situations where it can be nice to have a standalone flake8 image available.