### PR TITLE
Update to Go 1.11

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.10
+FROM golang:1.11
 
 RUN set -ex; \
     go get -u -v -t \


### PR DESCRIPTION
Updates to Go version 1.11 in order to make use of newer features, particularly native modules support.