### PR TITLE
[CSI-554] Add phpcs linter

### DIFF
--- a/linters/phpcs/Dockerfile
+++ b/linters/phpcs/Dockerfile
@@ -17,4 +17,4 @@ COPY ./composer.json /composer/
 RUN composer install -d "/composer"
 
 WORKDIR /workspace
-ENTRYPOINT ["/composer/vendor/bin/phpcs", "-s", "."]
+ENTRYPOINT ["/composer/vendor/bin/phpcs", "-s"]

--- a/linters/phpcs/Dockerfile
+++ b/linters/phpcs/Dockerfile
@@ -1,0 +1,20 @@
+FROM php:7.2
+
+# Install apt dependencies
+RUN apt-get update && apt-get install -qq -y --fix-missing --no-install-recommends \
+    git \
+    unzip \
+    zip \
+    ;
+
+# Install composer.
+RUN curl https://getcomposer.org/installer -s -o composer-setup.php \
+    && php composer-setup.php --quiet --install-dir=/usr/local/bin/ --filename=composer \
+    && rm composer-setup.php
+
+# Install phpcs and code standards libraries via Composer
+COPY ./composer.json /composer/
+RUN composer install -d "/composer"
+
+WORKDIR /workspace
+ENTRYPOINT ["/composer/vendor/bin/phpcs", "-s", "."]

--- a/linters/phpcs/README.md
+++ b/linters/phpcs/README.md
@@ -1,0 +1,31 @@
+# phpcs
+
+A minimal `phpcs` image useful for linting PHP files.
+
+## configuration
+
+This image supports linting for WordPress Core Standards, PHP Compatibility, and any library provided by [phpcs](https://github.com/squizlabs/PHP_CodeSniffer) including PSR-2.
+
+### PHP Compatibility Example:
+
+```
+docker run --rm -v `pwd`:/workspace wpengine/phpcs /workspace --standard=PHPCompatibility --runtime-set testVersion 7.2-
+```
+
+### WordPress Core Standards Example:
+
+```
+docker run --rm -v `pwd`:/workspace wpengine/phpcs /workspace --standard=WordPress
+```
+
+### PSR-2 Example:
+
+```
+docker run --rm -v `pwd`:/workspace wpengine/phpcs /workspace --standard=PSR2
+```
+
+### Using your own phpcs.xml
+
+```
+docker run --rm -v `pwd`:/workspace wpengine/phpcs /workspace --standard=./phpcs.xml
+```

--- a/linters/phpcs/composer.json
+++ b/linters/phpcs/composer.json
@@ -1,0 +1,9 @@
+{
+    "name": "wpengine/phpcs",
+    "require": {
+        "squizlabs/php_codesniffer": "^3.3",
+        "phpcompatibility/php-compatibility": "^8.2",
+        "wp-coding-standards/wpcs": "^1.0",
+        "dealerdirect/phpcodesniffer-composer-installer": "^0.4.4"
+    }
+}


### PR DESCRIPTION
A minimal `phpcs` image useful for linting PHP files.

This image supports linting for WordPress Core Standards, PHP Compatibility, and any library provided by [phpcs](https://github.com/squizlabs/PHP_CodeSniffer) including PSR-2.

 ### How to test this PR:

1. `cd` into the phpcs dir
2. Run `docker build --tag phpcs .`
3. Navigate to a PHP project and run any of the following commands:

#### PHP Compatibility:

```
docker run --rm -v `pwd`:/workspace phpcs /workspace --standard=PHPCompatibility --runtime-set testVersion 7.2-
```

#### WordPress Core Standards:

```
docker run --rm -v `pwd`:/workspace phpcs /workspace --standard=WordPress
```

#### PSR-2:

```
docker run --rm -v `pwd`:/workspace phpcs /workspace --standard=PSR2
```

#### Custom phpcs.xml

```
docker run --rm -v `pwd`:/workspace phpcs /workspace --standard=./phpcs.xml
```