### PR TITLE
Add wp-cli alpine image.

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 This repository contains Dockerfiles and configuration scripts for Docker images containing various utilities. The resulting images are typically hosted on Docker Hub via automated builds. These automated builds look for changes in this repo and will tag any updated images with latest (as long as they're in the master branch).
 
 If you would like to test an image, you can push to a branch with the branch-name called {image-you-care-about}-new-version, and docker-hub will publish a new image that is tagged terraform-new-version. For example, say I want to test a new terraform version... I could push a branch named terraform-0.11.7, and dockerhub will build a new terraform image with the tag terraform-0.11.7.
+
+## Adding new images
+
+To add a new image to be managed by this repository and automatically built, see the Confluence Wiki article named "How to add to base-images-public".

--- a/wp-cli/Dockerfile
+++ b/wp-cli/Dockerfile
@@ -1,0 +1,38 @@
+FROM alpine:edge
+
+ENV WP_CLI_VERSION 1.4.0
+
+ADD https://php.codecasts.rocks/php-alpine.rsa.pub /etc/apk/keys/php-alpine.rsa.pub
+
+RUN echo "http://php.codecasts.rocks/v3.6/php-7.1" >> /etc/apk/repositories && \
+    apk add --update --no-cache \
+    bash \
+    curl \
+    less \
+    freetype-dev libjpeg-turbo-dev libpng-dev \
+    mariadb-client \
+    php7 \
+    php7-ftp \
+    php7-gd \
+    php7-openssl \
+    php7-phar \
+    php7-iconv \
+    php7-mbstring \
+    php7-mongodb \
+    php7-mysqli \
+    php7-zlib
+
+ADD ./composer.sh /composer.sh
+RUN chmod u+x /composer.sh; sync && \
+    /composer.sh
+
+RUN rm -rf /tmp/src && \
+    rm -f /composer.sh \
+    rm -rf /var/cache/apk/*
+
+RUN composer create-project wp-cli/wp-cli:$WP_CLI_VERSION /usr/share/wp-cli --no-dev && \
+    composer clear-cache
+
+RUN ln -s /usr/share/wp-cli/bin/wp /usr/bin/wp
+
+ENTRYPOINT ["/usr/bin/wp", "--allow-root", "--path=/mnt"]

--- a/wp-cli/README.md
+++ b/wp-cli/README.md
@@ -1,0 +1,3 @@
+# WP-CLI on Alpine Linux
+
+[WP-CLI](http://wp-cli.org/) baked from [PHP Composer](https://getcomposer.org/) built on top of [Alpine Linux](https://alpinelinux.org/).

--- a/wp-cli/composer.sh
+++ b/wp-cli/composer.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+EXPECTED_SIGNATURE=$(curl https://composer.github.io/installer.sig)
+php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');"
+ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', 'composer-setup.php');")
+
+if [ "$EXPECTED_SIGNATURE" != "$ACTUAL_SIGNATURE" ]
+then
+    >&2 echo 'ERROR: Invalid installer signature'
+    rm composer-setup.php
+    exit 1
+fi
+
+php composer-setup.php --no-ansi --install-dir=/usr/bin --filename=composer --quiet
+RESULT=$?
+rm composer-setup.php
+exit $RESULT


### PR DESCRIPTION
Adding the core of a wp-cli image we've been using for another project that stopped being built. The older built version on DockerHub needs updated. :)