### PR TITLE
Update default node versions.

### DIFF
--- a/local-dev/5.6/Dockerfile
+++ b/local-dev/5.6/Dockerfile
@@ -32,7 +32,7 @@ RUN curl -L phpunit https://phar.phpunit.de/phpunit-5.phar > /tmp/phpunit.phar \
     && mv /tmp/phpunit.phar /usr/local/bin/phpunit
 
 # nvm environment variables
-ENV NODE_VERSION 11.1.0
+ENV NODE_VERSION 11.3.0
 ENV NVM_VERSION 0.33.11
 ENV NVM_DIR /usr/local/nvm
 

--- a/local-dev/5.6/Dockerfile
+++ b/local-dev/5.6/Dockerfile
@@ -26,6 +26,12 @@ RUN chmod +x /usr/local/bin/xlon.sh
 ADD xdebug-listen-off.sh /usr/local/bin/xloff.sh
 RUN chmod +x /usr/local/bin/xloff.sh
 
+ADD xdebug-on.sh /usr/local/bin/xdebugon.sh
+RUN chmod +x /usr/local/bin/xdebugon.sh
+
+ADD xdebug-off.sh /usr/local/bin/xdebugoff.sh
+RUN chmod +x /usr/local/bin/xdebugoff.sh
+
 # Install PHPUnit
 RUN curl -L phpunit https://phar.phpunit.de/phpunit-5.phar > /tmp/phpunit.phar \
     && chmod +x /tmp/phpunit.phar \

--- a/local-dev/5.6/xdebug-off.sh
+++ b/local-dev/5.6/xdebug-off.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed -i '/zend_extension=\/usr\/local\/lib\/php\/extensions\/no-debug-non-zts-20131226\/xdebug.so/d' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+ldconfig

--- a/local-dev/5.6/xdebug-on.sh
+++ b/local-dev/5.6/xdebug-on.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed -i '1s/^/zend_extension=\/usr\/local\/lib\/php\/extensions\/no-debug-non-zts-20131226\/xdebug.so\n/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+ldconfig

--- a/local-dev/7.0/Dockerfile
+++ b/local-dev/7.0/Dockerfile
@@ -26,6 +26,12 @@ RUN chmod +x /usr/local/bin/xlon.sh
 ADD xdebug-listen-off.sh /usr/local/bin/xloff.sh
 RUN chmod +x /usr/local/bin/xloff.sh
 
+ADD xdebug-on.sh /usr/local/bin/xdebugon.sh
+RUN chmod +x /usr/local/bin/xdebugon.sh
+
+ADD xdebug-off.sh /usr/local/bin/xdebugoff.sh
+RUN chmod +x /usr/local/bin/xdebugoff.sh
+
 # Install PHPUnit
 RUN curl -L phpunit https://phar.phpunit.de/phpunit-6.phar > /tmp/phpunit.phar \
     && chmod +x /tmp/phpunit.phar \

--- a/local-dev/7.0/Dockerfile
+++ b/local-dev/7.0/Dockerfile
@@ -32,7 +32,7 @@ RUN curl -L phpunit https://phar.phpunit.de/phpunit-6.phar > /tmp/phpunit.phar \
     && mv /tmp/phpunit.phar /usr/local/bin/phpunit
 
 # nvm environment variables
-ENV NODE_VERSION 11.1.0
+ENV NODE_VERSION 11.3.0
 ENV NVM_VERSION 0.33.11
 ENV NVM_DIR /usr/local/nvm
 

--- a/local-dev/7.0/xdebug-off.sh
+++ b/local-dev/7.0/xdebug-off.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed -i '/zend_extension=\/usr\/local\/lib\/php\/extensions\/no-debug-non-zts-20151012\/xdebug.so/d' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+ldconfig

--- a/local-dev/7.0/xdebug-on.sh
+++ b/local-dev/7.0/xdebug-on.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed -i '1s/^/zend_extension=\/usr\/local\/lib\/php\/extensions\/no-debug-non-zts-20151012\/xdebug.so\n/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+ldconfig

--- a/local-dev/7.1/Dockerfile
+++ b/local-dev/7.1/Dockerfile
@@ -35,7 +35,7 @@ RUN curl -L phpunit https://phar.phpunit.de/phpunit-7.phar > /tmp/phpunit.phar \
     && mv /tmp/phpunit.phar /usr/local/bin/phpunit
 
 # nvm environment variables
-ENV NODE_VERSION 11.1.0
+ENV NODE_VERSION 11.3.0
 ENV NVM_VERSION 0.33.11
 ENV NVM_DIR /usr/local/nvm
 

--- a/local-dev/7.1/Dockerfile
+++ b/local-dev/7.1/Dockerfile
@@ -29,6 +29,12 @@ RUN chmod +x /usr/local/bin/xlon.sh
 ADD xdebug-listen-off.sh /usr/local/bin/xloff.sh
 RUN chmod +x /usr/local/bin/xloff.sh
 
+ADD xdebug-on.sh /usr/local/bin/xdebugon.sh
+RUN chmod +x /usr/local/bin/xdebugon.sh
+
+ADD xdebug-off.sh /usr/local/bin/xdebugoff.sh
+RUN chmod +x /usr/local/bin/xdebugoff.sh
+
 # Install PHPUnit
 RUN curl -L phpunit https://phar.phpunit.de/phpunit-7.phar > /tmp/phpunit.phar \
     && chmod +x /tmp/phpunit.phar \

--- a/local-dev/7.1/xdebug-off.sh
+++ b/local-dev/7.1/xdebug-off.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed -i '/zend_extension=\/usr\/local\/lib\/php\/extensions\/no-debug-non-zts-20160303\/xdebug.so/d' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+ldconfig

--- a/local-dev/7.1/xdebug-on.sh
+++ b/local-dev/7.1/xdebug-on.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed -i '1s/^/zend_extension=\/usr\/local\/lib\/php\/extensions\/no-debug-non-zts-20160303\/xdebug.so\n/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+ldconfig

--- a/local-dev/7.2/Dockerfile
+++ b/local-dev/7.2/Dockerfile
@@ -35,7 +35,7 @@ RUN curl -L phpunit https://phar.phpunit.de/phpunit-7.phar > /tmp/phpunit.phar \
     && mv /tmp/phpunit.phar /usr/local/bin/phpunit
 
 # nvm environment variables
-ENV NODE_VERSION 11.1.0
+ENV NODE_VERSION 11.3.0
 ENV NVM_VERSION 0.33.11
 ENV NVM_DIR /usr/local/nvm
 

--- a/local-dev/7.2/Dockerfile
+++ b/local-dev/7.2/Dockerfile
@@ -29,6 +29,12 @@ RUN chmod +x /usr/local/bin/xlon.sh
 ADD xdebug-listen-off.sh /usr/local/bin/xloff.sh
 RUN chmod +x /usr/local/bin/xloff.sh
 
+ADD xdebug-on.sh /usr/local/bin/xdebugon.sh
+RUN chmod +x /usr/local/bin/xdebugon.sh
+
+ADD xdebug-off.sh /usr/local/bin/xdebugoff.sh
+RUN chmod +x /usr/local/bin/xdebugoff.sh
+
 # Install PHPUnit
 RUN curl -L phpunit https://phar.phpunit.de/phpunit-7.phar > /tmp/phpunit.phar \
     && chmod +x /tmp/phpunit.phar \

--- a/local-dev/7.2/xdebug-off.sh
+++ b/local-dev/7.2/xdebug-off.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed -i '/zend_extension=\/usr\/local\/lib\/php\/extensions\/no-debug-non-zts-20170718\/xdebug.so/d' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+ldconfig

--- a/local-dev/7.2/xdebug-on.sh
+++ b/local-dev/7.2/xdebug-on.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+sed -i '1s/^/zend_extension=\/usr\/local\/lib\/php\/extensions\/no-debug-non-zts-20170718\/xdebug.so\n/' /usr/local/etc/php/conf.d/docker-php-ext-xdebug.ini
+ldconfig


### PR DESCRIPTION
Just specifying "lts" doesn't work for whatever reason and, bumping this periodically gives us a good excuse to update the images anyway for any upstream changes.