### PR TITLE
pin fluentd bq plugin to the version we use on the farm

### DIFF
--- a/fluentd/Dockerfile
+++ b/fluentd/Dockerfile
@@ -6,7 +6,7 @@ RUN apk add --update --virtual .build-deps \
         fluent-plugin-record-modifier \
         fluent-plugin-secure-forward \
         fluent-plugin-formatter_sprintf \
-        fluent-plugin-bigquery \
+        fluent-plugin-bigquery:1.2.0 \
  && sudo gem sources --clear-all \
  && apk del .build-deps \
  && rm -rf /var/cache/apk/* \


### PR DESCRIPTION
v 1.2.0 pulled from td-agent/Gemfile-3.lock in server-cm