### PR TITLE
[NOJIRA] Add wpengine/composer

### DIFF
--- a/composer/Dockerfile
+++ b/composer/Dockerfile
@@ -1,0 +1,4 @@
+FROM composer:1.8
+
+WORKDIR /workspace
+

--- a/composer/README.md
+++ b/composer/README.md
@@ -1,0 +1,4 @@
+# composer
+
+A minimal `composer` image to serve as a control on inadvertent and possibly malicious upstream changes.
+


### PR DESCRIPTION
> Brandon DuRette: I’d like to see us running not running containers from public repos because I have concerns about software supply chain. Definitely not the most important matter now, but if we’re pulling from repos that we control, we’re less vulnerable to:
> * Compromised images in public repos (https://www.theregister.co.uk/2018/11/26/npm_repo_bitcoin_stealer/)
> * Downtime when public repos go offline (PEAR repository)

This PR would help resolve the first concern. Thoughts?