### PR TITLE
Use stretch so we get working apt sources

### DIFF
--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.2
+FROM ruby:2.4.6-stretch
 RUN gem install fpm
 WORKDIR /workspace
 ENTRYPOINT ["fpm"]


### PR DESCRIPTION
Debian Jessie mirrors have done shifted on us, so moving this image to use Stretch instead:

see: https://jenkins.wpengine.io/blue/organizations/jenkins/WPEngineGitHubRepos%2Fpear-shaped/detail/PR-16/1/pipeline

```
Step 1/7 : FROM wpengine/fpm

 ---> 8485ec821208

Step 2/7 : MAINTAINER "WP Engine Tech Ops Team <techops@wpengine.com>"

 ---> Running in c0682312975a

Removing intermediate container c0682312975a

 ---> 987f909940dc

Step 3/7 : RUN apt update && apt install -y php-pear apt-transport-https

 ---> Running in 902b8f76f38c



WARNING: apt does not have a stable CLI interface yet. Use with caution in scripts.



Get:1 http://security.debian.org jessie/updates InRelease [44.9 kB]

Ign http://deb.debian.org jessie InRelease

Get:2 http://deb.debian.org jessie-updates InRelease [7340 B]

Get:3 http://deb.debian.org jessie Release.gpg [2420 B]

Get:4 http://deb.debian.org jessie Release [148 kB]

Get:5 http://security.debian.org jessie/updates/main amd64 Packages [824 kB]

Get:6 http://deb.debian.org jessie/main amd64 Packages [9098 kB]

Fetched 10.1 MB in 7s (1414 kB/s)

W: Failed to fetch http://deb.debian.org/debian/dists/jessie-updates/InRelease  Unable to find expected entry 'main/binary-amd64/Packages' in Release file (Wrong sources.list entry or malformed file)

```

related: https://github.com/wpengine/hashicorp-packages/pull/40/commits/4adce9d262a2e8b83a970cbc38f777b86ec1f8b5