### PR TITLE
[COE-1306] add golangci-lint to base golang image

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -19,6 +19,7 @@ RUN set -ex; \
         github.com/jstemmer/go-junit-report \
         github.com/axw/gocov/gocov \
         github.com/AlekSi/gocov-xml \
+        github.com/golangci/golangci-lint/cmd/golangci-lint \
     ; \
     gometalinter --install; \
     mv /go/bin/* /usr/local/go/bin/

--- a/golang/README.md
+++ b/golang/README.md
@@ -5,11 +5,22 @@ Golang base image with additional packages to assist in running unit tests.
 ## Usage
 
 As a linter:
+
+With gometalinter (deprecated 04/07/19):
 ```
 docker run --rm \
     -v $(pwd):/go/src/${package_name} \
     -w /go/src/${package_name} \
     wpengine/golang gometalinter --vendor --disable-all --enable=golint --enable=vet --enable=gofmt ./...
+```
+
+With golangci-lint:
+```
+docker run --rm -v \
+    -v $(pwd):/go/src/${package_name} \
+    -w /go/src/${package_name} \
+    wpengine/golang golangci-lint run --no-config --issues-exit-code=0 \
+    --disable-all --enable=vet --enable=golint --enable=gofmt
 ```
 
 Run unit tests:


### PR DESCRIPTION
**[JIRA ticket](https://wpengine.atlassian.net/browse/COE-1306)**

Gometalinter has been deprecated and was archived on April 7th of this year, so this PR installs golangci-lint into the base image so that services using this base image can start switching over (i.e. the edge-agent) to be able to use an updated (and faster) linter 🎉 