### PR TITLE
Allow different nesting for md headers (MD024)

### DIFF
--- a/linters/mdl/markdown/wpe_markdown.rb
+++ b/linters/mdl/markdown/wpe_markdown.rb
@@ -3,5 +3,8 @@ all
 # Set line length to 120 characters from 80.
 rule 'MD013', :line_length => 120
 
+# Allow headers to share names if separated by a larger header.
+rule 'MDO24', :allow_different_nesting => true
+
 # Set numbered lists to expect an increment in value.
 rule 'MD029', :style => "ordered"


### PR DESCRIPTION
Adding rule to allow more flexibility in header composition.

This link illustrates the issue I'm running into. 
https://github.com/markdownlint/markdownlint/blob/master/docs/RULES.md#md024---multiple-headers-with-the-same-content