### PR TITLE
[Golang 1.2.0] Removing deprecated dependencies

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -2,26 +2,18 @@ FROM golang:1.12.8
 
 RUN set -ex; \
     apt-get update && apt-get install -y --no-install-recommends \
-        protobuf-compiler \
+      protobuf-compiler \
     ; \
     rm -rf /var/lib/apt/lists/*; \
     go get -u -v -t \
-        github.com/golang/protobuf/proto \
-        github.com/golang/protobuf/protoc-gen-go \
-        google.golang.org/grpc \
-    ;
-
-RUN set -ex; \
-    go get -u -v -t \
-        github.com/alecthomas/gometalinter \
-        github.com/Masterminds/glide \
-        github.com/golang/dep/cmd/dep \
-        github.com/jstemmer/go-junit-report \
-        github.com/axw/gocov/gocov \
-        github.com/AlekSi/gocov-xml \
-        github.com/golangci/golangci-lint/cmd/golangci-lint \
+      github.com/golang/protobuf/proto \
+      github.com/golang/protobuf/protoc-gen-go \
+      google.golang.org/grpc \
+      github.com/jstemmer/go-junit-report \
+      github.com/axw/gocov/gocov \
+      github.com/AlekSi/gocov-xml \
+      github.com/golangci/golangci-lint/cmd/golangci-lint \
     ; \
-    gometalinter --install; \
     mv /go/bin/* /usr/local/go/bin/
 
 COPY unit_tests.sh .

--- a/golang/README.md
+++ b/golang/README.md
@@ -4,36 +4,29 @@ Golang base image with additional packages to assist in running unit tests.
 
 ## Usage
 
-As a linter:
-
-With gometalinter (deprecated 04/07/19):
+Lint files:
 ```
 docker run --rm \
-    -v $(pwd):/go/src/${package_name} \
-    -w /go/src/${package_name} \
-    wpengine/golang gometalinter --vendor --disable-all --enable=golint --enable=vet --enable=gofmt ./...
-```
-
-With golangci-lint:
-```
-docker run --rm -v \
-    -v $(pwd):/go/src/${package_name} \
-    -w /go/src/${package_name} \
-    wpengine/golang golangci-lint run --no-config --issues-exit-code=0 \
-    --disable-all --enable=vet --enable=golint --enable=gofmt
+  -v $(pwd):/go/src/${package_name} \
+  -w /go/src/${package_name} \
+  wpengine/golang
+  golangci-lint run --no-config --issues-exit-code=0 --disable-all --enable=vet --enable=golint --enable=gofmt
 ```
 
 Run unit tests:
 ```
-docker run --rm -v \
-    $(pwd):/go/src/${package_name} \
-    wpengine/golang /bin/bash unit_tests.sh -p ${package_name}
+docker run --rm \
+  -v $(pwd):/go/src/${package_name} \
+  wpengine/golang
+  /bin/bash unit_tests.sh -p ${package_name}
 ```
 
 Installing dependencies:
 ```
-docker run --rm -v \
-    $(pwd):/go/src/${package_name} \
-    -w /go/src/${package_name} \
-    wpengine/golang glide install -v
+docker run --rm  \
+  -v $(pwd):/go/src/${package_name} \
+  -w /go/src/${package_name} \
+  wpengine/golang
+  sh -c "git config --global url.'https://$(GITHUB_TOKEN):x-oauth-basic@github.com/'.insteadOf 'https://github.com/' \
+  && go mod vendor"
 ```


### PR DESCRIPTION
Removing the following dependencies from the Golang image:
* `gometalinter` (deprecated as of April 2019)
* `dep` (deprecated in favor of `mod`)
* `glide` (deprecated in favor of `mod`)

Removing these dependencies reduced the image size by 260MB.