### PR TITLE
[golang] Update golang image README

### DIFF
--- a/golang/README.md
+++ b/golang/README.md
@@ -41,7 +41,7 @@ docker run --rm --volume `pwd`/artifacts:/go/src/$(package_name)/artifacts wpeng
 
 ```
 
-Installing dependencies:
+Install dependencies:
 ```
 docker run --rm  \
   -v $(pwd):/go/src/${package_name} \


### PR DESCRIPTION
I'm introducing a new tagging format for the `wpengine/golang` image with this change. The image will be tagged as `1.12-wpe0`. We decided on this tagging format from [a discussion](https://wpengine.slack.com/archives/CEJN4Q6SD/p1566856924002300) in the Slack channel #golang-guild.

The format is `wpengine/golang:<major-golang-version>-wpe<toolset-version>` and is further described in the README.