### PR TITLE
Add gocov-html to the golang base image

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -17,6 +17,7 @@ RUN set -ex; \
     go get -u -v -t \
         github.com/jstemmer/go-junit-report \
         github.com/axw/gocov/gocov \
+	github.com/matm/gocov-html \
         github.com/AlekSi/gocov-xml \
         github.com/golangci/golangci-lint/cmd/golangci-lint \
     ; \

--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -17,7 +17,7 @@ RUN set -ex; \
     go get -u -v -t \
         github.com/jstemmer/go-junit-report \
         github.com/axw/gocov/gocov \
-	github.com/matm/gocov-html \
+        github.com/matm/gocov-html \
         github.com/AlekSi/gocov-xml \
         github.com/golangci/golangci-lint/cmd/golangci-lint \
     ; \


### PR DESCRIPTION
Being able to publish HTML reports is useful in our Jenkins pipelines. The requires the gocov-html package.