### PR TITLE
update to latest in 0.11 series

### DIFF
--- a/gcloud/terraform/Dockerfile
+++ b/gcloud/terraform/Dockerfile
@@ -1,8 +1,10 @@
 FROM google/cloud-sdk
 
-ENV TERRAFORM_VERSION=0.11.11
-ENV TERRAFORM_SHA256SUM=94504f4a67bad612b5c8e3a4b7ce6ca2772b3c1559630dfd71e9c519e3d6149c
-ENV TERRAFORM_URL=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_linux_amd64.zip
+ENV OS=linux
+ENV ARCH=amd64
+ENV TERRAFORM_VERSION=0.11.15
+ENV TERRAFORM_SHA256SUM=e6c8c884de6c353cf98252c5e11faf972d4b30b5d070ab5ff70eaf92660a5aac
+ENV TERRAFORM_URL=https://releases.hashicorp.com/terraform/${TERRAFORM_VERSION}/terraform_${TERRAFORM_VERSION}_${OS}_${ARCH}.zip
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y unzip jq
 


### PR DESCRIPTION
Hashicorp signing key was exfiltrated.  0.11.15 uses the replacement key to validate module signatures during init

https://discuss.hashicorp.com/t/hcsec-2021-12-codecov-security-event-and-hashicorp-gpg-key-exposure/23512
https://discuss.hashicorp.com/t/terraform-updates-for-hcsec-2021-12/23570
