### PR TITLE
[SRE-8391] Adding docker image with gcloud and awscli

### DIFF
--- a/ubuntu/README.md
+++ b/ubuntu/README.md
@@ -1,0 +1,4 @@
+# ubuntu
+
+Collection of images that based on the ubuntu image specifically, whether a
+tagged release or latest.

--- a/ubuntu/docker/Dockerfile
+++ b/ubuntu/docker/Dockerfile
@@ -10,7 +10,6 @@ RUN chmod 0444 \
 		/usr/share/keyrings/cloud.google.gpg \
 	&& apt update \
 	&& DEBIAN_FRONTEND=noninteractive apt install -y \
-		curl \
 		docker.io \
 		google-cloud-sdk \
 		python3-pip \

--- a/ubuntu/docker/Dockerfile
+++ b/ubuntu/docker/Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:latest
+
+ENV GCP_KEYRING_SRC https://packages.cloud.google.com/apt/doc/apt-key.gpg
+
+ADD ${GCP_KEYRING_SRC} /usr/share/keyrings/cloud.google.gpg
+COPY google-cloud-sdk.list /etc/apt/sources.list.d/google-cloud-sdk.list
+
+RUN chmod 0444 \
+		/etc/apt/sources.list.d/google-cloud-sdk.list \
+		/usr/share/keyrings/cloud.google.gpg \
+	&& apt update \
+	&& DEBIAN_FRONTEND=noninteractive apt install -y \
+		curl \
+		docker.io \
+		google-cloud-sdk \
+		python3-pip \
+	&& pip3 install awscliv2 \
+	&& apt clean

--- a/ubuntu/docker/README.md
+++ b/ubuntu/docker/README.md
@@ -1,0 +1,3 @@
+# docker
+
+Image starting with `ubuntu:latest` adding Google Cloud CLI and AWS CLI v2.

--- a/ubuntu/docker/google-cloud-sdk.list
+++ b/ubuntu/docker/google-cloud-sdk.list
@@ -1,0 +1,1 @@
+deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main


### PR DESCRIPTION
This adds a Docker image that includes the Docker, Google Cloud CLI, and AWS CLI packages which should update all these packages with a simple rebuild.