### PR TITLE
[NOJIRA] Aldd AWS CLI v1 to the dockerception image

### DIFF
--- a/ubuntu/docker/Dockerfile
+++ b/ubuntu/docker/Dockerfile
@@ -10,6 +10,7 @@ RUN chmod 0444 \
 		/usr/share/keyrings/cloud.google.gpg \
 	&& apt update \
 	&& DEBIAN_FRONTEND=noninteractive apt install -y \
+		awscli \
 		docker.io \
 		google-cloud-sdk \
 		python3-pip \


### PR DESCRIPTION
We already have AWS CLI v2 in the new dockerception image, but the lack of AWS CLI v1 has already proven surprising. It may no longer be actively maintained by AWS, but AWS CLI v1 is currently still the most used version of AWS CLI, so it makes sense to have it available.