### PR TITLE
fix: FPM image pinned to EOL ruby and debian

### DIFF
--- a/fpm/Dockerfile
+++ b/fpm/Dockerfile
@@ -1,4 +1,4 @@
-FROM ruby:2.4.6-stretch
+FROM ruby:2
 RUN gem install fpm -v 1.11.0
 WORKDIR /workspace
 ENTRYPOINT ["fpm"]


### PR DESCRIPTION
Ruby 2.4 went EOL 2020-03-31.
Debian stretch went EOL 2020-07-06.


I disagre with pinning FPM to 1.11, but I have confirmed that it is functional under Ruby 2.7, which is where this tag currently points.
