### PR TITLE
[EDGE-5722] Updated the gocov-html package location.

### DIFF
--- a/golang/Dockerfile
+++ b/golang/Dockerfile
@@ -17,7 +17,7 @@ RUN set -ex; \
     go get -u -v -t \
         github.com/jstemmer/go-junit-report \
         github.com/axw/gocov/gocov \
-        github.com/matm/gocov-html \
+        github.com/matm/gocov-html/cmd/gocov-html@latest \
         github.com/AlekSi/gocov-xml \
         github.com/golangci/golangci-lint/cmd/golangci-lint \
     ; \


### PR DESCRIPTION
## JIRA Ticket

[EDGE-5722](https://wpengine.atlassian.net/browse/EDGE-5722)

##What Are We Doing Here

We're updating how we pull in the `gocov-html` package because the vendor changed it's location in the latest build.

[EDGE-5722]: https://wpengine.atlassian.net/browse/EDGE-5722?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ