### PR TITLE
[IED-1470] Updating to use golden bionic docker image

### DIFF
--- a/ansible/Dockerfile
+++ b/ansible/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM gcr.io/wpe-cr/ubuntu_bionic_golden_base:latest
 
 ENV ANSIBLE_VERSION=2.7.9
 ENV ANSIBLE_LINT_VERSION=4.1.0


### PR DESCRIPTION
Using Golden ubuntu docker image with extended support token setup.
https://github.com/wpengine/server-cm/pull/10620/files