### PR TITLE
[IED-2737] Update apt source references to use https

### DIFF
--- a/ubuntu/docker/google-cloud-sdk.list
+++ b/ubuntu/docker/google-cloud-sdk.list
@@ -1,1 +1,1 @@
-deb [signed-by=/usr/share/keyrings/cloud.google.gpg] http://packages.cloud.google.com/apt cloud-sdk main
+deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main


### PR DESCRIPTION
[Google instructions](https://cloud.google.com/artifact-registry/docs/os-packages/debian/configure#ubuntu-vm) for fetching the GAR apt transport package incorrectly indicate to use http instead of https for the apt source repo url. 

This is to update https endpoint. This is tested and works.